### PR TITLE
Fix a couple of problems I found while using the Package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@
 
 from setuptools import setup
 
-setup(include_package_data=True)
+setup(py_modules=['QSmooth'])


### PR DESCRIPTION
- with SDSS spectra (possibly others, unsure - I guess the problem were `inf` in the flux or error array) the MAD would be zero, causing a runtime error. Solved by changing `np.nan(...)` to `~np.isfinite(...)`
- There were a couple of instances of `== True` that I removed
- The package was not installable (it would install, but would not pull the `QSmooth.py` script itself, making it effectively unusable). This should now be fixed.